### PR TITLE
Update API call to point to updated WAQI endpoint

### DIFF
--- a/pwaqi/__init__.py
+++ b/pwaqi/__init__.py
@@ -21,7 +21,7 @@ def getJSKey(locationName):
 		todecode = r.text[pos+20:pos+76]
 		key = decoder(todecode)
 		print("key = {}".format(key))
-		return key 
+		return key
 	return ""
 
 def getToken(stationCode):
@@ -33,7 +33,7 @@ def getUID():
 	return  "abcde" + datetime.now().strftime("%s000")
 
 def getStationObservation(stationCode, locationName='', language = "en"):
-	r = requests.post("https://waqi.info/api/feed/@" + str(stationCode) + "/obs." + language + ".json",
+	r = requests.post('https://api.waqi.info/api/feed/@%d/obs.%s.json' % (stationCode, language),
 		data = {
 #			'token': getToken(stationCode),
 #			'key': getJSKey(locationName),


### PR DESCRIPTION
Addresses #4 issue where API results were stale. It seems the official API endpoint has changed or perhaps wasn't official when pwaqi was created (@see http://aqicn.org/json-api/doc/ for official API). Changing from `https://waqi.info/api/feed` to `https://api.waqi.info/api` seems to give up-to-date results.


Previous result of API call (note date is over 10 days old)

```
{'aqi': 24,
 'city': {'geo': ['41.38534', '2.153822'],
  'id': 'Spain/Catalunya/Barcelona%28Eixample%29',
  'idx': 6669,
  'name': 'Barcelona (Eixample), Catalunya',
  'url': 'http://aqicn.org/city/spain/catalunya/barcelona-eixample/'},
 'dominentpol': '',
 'iaqi': [{'cur': 24, 'max': 32, 'min': 18, 'p': 'pm10'},
  {'cur': 12, 'max': 21, 'min': 1, 'p': 'o3'},
  {'cur': 23, 'max': 63, 'min': 11, 'p': 'no2'},
  {'cur': 10, 'max': 12, 'min': 4, 'p': 't'},
  {'cur': 1012, 'max': 1018, 'min': 1010, 'p': 'p'},
  {'cur': 81, 'max': 95, 'min': 71, 'p': 'h'}],
 'time': '2017-01-28T06:00:00+09:00'}
```

With updated endpoint to https://api.waqi.info/api (note results are as of today's date):

```
{'aqi': 22,
 'city': {'geo': ['41.38534', '2.153822'],
  'id': 'Spain/Catalunya/Barcelona%28Eixample%29',
  'idx': 6669,
  'name': 'Barcelona (Eixample), Catalunya',
  'url': 'http://aqicn.org/city/spain/catalunya/barcelona-eixample/'},
 'dominentpol': '',
 'iaqi': [{'cur': 22, 'max': 27, 'min': 16, 'p': 'pm10'},
  {'cur': 11, 'max': 21, 'min': 1, 'p': 'o3'},
  {'cur': 32, 'max': 65, 'min': 16, 'p': 'no2'},
  {'cur': 12, 'max': 13, 'min': 6, 'p': 't'},
  {'cur': 993, 'max': 993, 'min': 993, 'p': 'p'},
  {'cur': 74, 'max': 93, 'min': 35, 'p': 'h'}],
 'time': '2017-02-11T11:00:00+09:00'}
```